### PR TITLE
Explicitly handle UTF-8 encoding

### DIFF
--- a/yahoo.py
+++ b/yahoo.py
@@ -75,7 +75,9 @@ def archive_email(yga, reattach=True, save=True, html=False):
 			         print "ERROR: Read timeout, retrying"
 			         time.sleep(HOLDOFF)
 
-        eml = email.message_from_string(raw_json['rawEmail'])
+        # rawEmail needs to be explicitly converted to UTF-8:
+	as_utf8 = raw_json['rawEmail'].encode('utf8')
+	eml = email.message_from_string(as_utf8)
 
         if (save or reattach) and message['hasAttachments']:
             atts = {}


### PR DESCRIPTION
The body of emails as stored in the JSON response is actually in UTF-8, but email.message_from_string() seems to be expecting ASCII. Explicitly encoding the body text seems to fix the issue.